### PR TITLE
Add and name some SceGxmProgram fields

### DIFF
--- a/vita3k/gxm/include/gxm/types.h
+++ b/vita3k/gxm/include/gxm/types.h
@@ -1415,9 +1415,10 @@ struct SceGxmProgram {
     std::uint8_t unk17;
 
     std::uint32_t unk18;
-    std::uint32_t unk1C;
-
-    std::uint32_t unk20; // bit 6 denotes whether a frag shader writes directly to output (usees __nativecolor modifier) or not
+    
+    std::uint32_t texunit_flags1;
+    std::uint32_t texunit_flags2; // bit 6 denotes whether a frag shader writes directly to output (usees __nativecolor modifier) or not
+    
     std::uint32_t parameter_count;
     std::uint32_t parameters_offset; // Number of bytes from the start of this field to the first parameter.
     std::uint32_t varyings_offset; // offset to vertex outputs / fragment inputs, relative to this field
@@ -1458,6 +1459,7 @@ struct SceGxmProgram {
     std::uint32_t unk_8C;
     std::uint32_t container_count;
     std::uint32_t container_offset;
+    std::uint32_t sampler_query_info_offset; // Offset to array of uint16_t
 
     SceGxmProgramType get_type() const {
         return static_cast<SceGxmProgramType>(type & 1);


### PR DESCRIPTION
Texunit Flags
There are 4 bits for each of the 16 texunits. Bit 0 tells if the texunit is being sampled non dependently, Bit 1 tells if it is being sampled dependently. Both of these bits can be active simultaneously in one program. The remaining flags are unknown.

Sampler Info Query
If there are samplers used in the shader program sampler_info_query_offset will point to an array of 16 uint16_t.

The low 8 bits for each uint16_t contains a bitmask of the different precisions at which the sampler is queried within the program. Those precisions are U8, S8, U16, S16, U32, S32, F16, F32; not specifically in that order. 

The first 2 bits of the high 8 bits is the query_component_count - 1. 

The remaining bits are seemingly flags about the texture query. Bit 11(0x800) is the flag for if the query is a cube map query. Bits 12(0x1000) and 13(0x2000) are related to shadow map and gather4 texture queries. The other remaining bits are unknown.